### PR TITLE
fix: github actions subpage was working only for default service

### DIFF
--- a/plugins/github-actions/src/plugin.ts
+++ b/plugins/github-actions/src/plugin.ts
@@ -23,6 +23,10 @@ export const rootRouteRef = createRouteRef({
   path: '/github-actions',
   title: 'GitHub Actions',
 });
+export const projectRouteRef = createRouteRef({
+  path: '/github-actions/:kind/:optionalNamespaceAndName/',
+  title: 'GitHub Actions for project',
+});
 export const buildRouteRef = createRouteRef({
   path: '/github-actions/workflow-run/:id',
   title: 'GitHub Actions Workflow Run',
@@ -32,6 +36,7 @@ export const plugin = createPlugin({
   id: 'github-actions',
   register({ router }) {
     router.addRoute(rootRouteRef, WorkflowRunsPage);
+    router.addRoute(projectRouteRef, WorkflowRunsPage);
     router.addRoute(buildRouteRef, WorkflowRunDetailsPage);
   },
 });


### PR DESCRIPTION
## Enable /github-actions to show different projects

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Show a particular project based on params in URL, e.g. http://localhost:3000/github-actions/Component/sample-service/
#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] add new route to github actions plugin
- [x] based on params in the route fetch the project's actions 
