### PR TITLE
GitHub actions widget

### DIFF
--- a/microsite/pages/en/index.js
+++ b/microsite/pages/en/index.js
@@ -471,8 +471,8 @@ class Index extends React.Component {
                 Cloud Native Computing Foundation
               </a>{' '}
               sandbox project
+              <div className="cncf-logo" />
             </Block.SmallTitle>
-            <div className="cncf-logo" />
           </Block.Container>
         </Block>
       </main>

--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -1072,6 +1072,7 @@ code {
 }
 
 .cncf-block {
+  padding-top: 40px;
   text-align: center;
 }
 
@@ -1080,4 +1081,5 @@ code {
   width: 100%;
   height: 100px;
   margin-bottom: 40px;
+  margin-top: 20px;
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docgen": "lerna run docgen",
     "docker-build:app": "yarn workspace example-app build && docker build . -t spotify/backstage",
     "docker-build": "yarn tsc && yarn workspace example-backend build-image",
-    "create-plugin": "backstage-cli create-plugin",
+    "create-plugin": "backstage-cli create-plugin --scope backstage --no-private",
     "remove-plugin": "backstage-cli remove-plugin",
     "release": "if [ \"$(git symbolic-ref --short HEAD)\" = master ]; then echo \"don't try to release master\"; exit 1; else lerna version --no-push --force-publish; fi",
     "prettier:check": "prettier --check .",

--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -21,6 +21,7 @@ import inquirer, { Answers, Question } from 'inquirer';
 import { exec as execCb } from 'child_process';
 import { resolve as resolvePath } from 'path';
 import os from 'os';
+import { Command } from 'commander';
 import {
   parseOwnerIds,
   addCodeownersEntry,
@@ -32,12 +33,12 @@ import { version as backstageVersion } from '../../lib/version';
 
 const exec = promisify(execCb);
 
-async function checkExists(rootDir: string, id: string) {
-  await Task.forItem('checking', id, async () => {
-    const destination = resolvePath(rootDir, 'plugins', id);
-
+async function checkExists(destination: string) {
+  await Task.forItem('checking', destination, async () => {
     if (await fs.pathExists(destination)) {
-      const existing = chalk.cyan(destination.replace(`${rootDir}/`, ''));
+      const existing = chalk.cyan(
+        destination.replace(`${paths.targetRoot}/`, ''),
+      );
       throw new Error(
         `A plugin with the same name already exists: ${existing}\nPlease try again with a different plugin ID`,
       );
@@ -86,10 +87,9 @@ export const addExportStatement = async (
 
 export async function addPluginDependencyToApp(
   rootDir: string,
-  pluginName: string,
+  pluginPackage: string,
   versionStr: string,
 ) {
-  const pluginPackage = `@backstage/plugin-${pluginName}`;
   const packageFilePath = 'packages/app/package.json';
   const packageFile = resolvePath(rootDir, packageFilePath);
 
@@ -116,8 +116,11 @@ export async function addPluginDependencyToApp(
   });
 }
 
-export async function addPluginToApp(rootDir: string, pluginName: string) {
-  const pluginPackage = `@backstage/plugin-${pluginName}`;
+export async function addPluginToApp(
+  rootDir: string,
+  pluginName: string,
+  pluginPackage: string,
+) {
   const pluginNameCapitalized = pluginName
     .split('-')
     .map(name => capitalize(name))
@@ -175,7 +178,7 @@ export async function movePlugin(
   });
 }
 
-export default async () => {
+export default async (cmd: Command) => {
   const codeownersPath = await getCodeownersFilePath(paths.targetRoot);
 
   const questions: Question[] = [
@@ -221,20 +224,29 @@ export default async () => {
   }
 
   const answers: Answers = await inquirer.prompt(questions);
-
+  const name = cmd.scope
+    ? `@${cmd.scope.replace(/^@/, '')}/plugin-${answers.id}`
+    : `plugin-${answers.id}`;
+  const npmRegistry = cmd.npmRegistry && cmd.scope ? cmd.npmRegistry : '';
+  const privatePackage = cmd.private === false ? false : true;
+  const isMonoRepo = await fs.pathExists(paths.resolveTargetRoot('lerna.json'));
   const appPackage = paths.resolveTargetRoot('packages/app');
   const templateDir = paths.resolveOwn('templates/default-plugin');
   const tempDir = resolvePath(os.tmpdir(), answers.id);
-  const pluginDir = paths.resolveTargetRoot('plugins', answers.id);
+  const pluginDir = isMonoRepo
+    ? paths.resolveTargetRoot('plugins', answers.id)
+    : paths.resolveTargetRoot(answers.id);
   const ownerIds = parseOwnerIds(answers.owner);
-  const { version } = await fs.readJson(paths.resolveTargetRoot('lerna.json'));
+  const { version } = isMonoRepo
+    ? await fs.readJson(paths.resolveTargetRoot('lerna.json'))
+    : { version: '0.1.0' };
 
   Task.log();
   Task.log('Creating the plugin...');
 
   try {
     Task.section('Checking if the plugin ID is available');
-    await checkExists(paths.targetRoot, answers.id);
+    await checkExists(pluginDir);
 
     Task.section('Creating a temporary plugin directory');
     await createTemporaryPluginFolder(tempDir);
@@ -244,6 +256,9 @@ export default async () => {
       ...answers,
       version,
       backstageVersion,
+      name,
+      privatePackage,
+      npmRegistry,
     });
 
     Task.section('Moving to final location');
@@ -254,10 +269,10 @@ export default async () => {
 
     if (await fs.pathExists(appPackage)) {
       Task.section('Adding plugin as dependency in app');
-      await addPluginDependencyToApp(paths.targetRoot, answers.id, version);
+      await addPluginDependencyToApp(paths.targetRoot, name, version);
 
       Task.section('Import plugin in app');
-      await addPluginToApp(paths.targetRoot, answers.id);
+      await addPluginToApp(paths.targetRoot, answers.id, name);
     }
 
     if (ownerIds && ownerIds.length) {
@@ -269,11 +284,7 @@ export default async () => {
     }
 
     Task.log();
-    Task.log(
-      `🥇  Successfully created ${chalk.cyan(
-        `@backstage/plugin-${answers.id}`,
-      )}`,
-    );
+    Task.log(`🥇  Successfully created ${chalk.cyan(`${name}`)}`);
     Task.log();
     Task.exit();
   } catch (error) {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -62,6 +62,9 @@ export function registerCommands(program: CommanderStatic) {
   program
     .command('create-plugin')
     .description('Creates a new plugin in the current repository')
+    .option('--scope <scope>', 'NPM scope')
+    .option('--npm-registry <URL>', 'NPM registry URL')
+    .option('--no-private', 'Public NPM Package')
     .action(
       lazy(() => import('./create-plugin/createPlugin').then(m => m.default)),
     );

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -1,11 +1,14 @@
 {
-  "name": "@backstage/plugin-{{id}}",
+  "name": "{{name}}",
   "version": "{{version}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
+{{#if privatePackage}}  "private": {{privatePackage}},
+{{/if}}
   "publishConfig": {
+{{#if npmRegistry}}    "registry": "{{npmRegistry}}",
+{{/if}}
     "access": "public",
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@backstage/config": "^0.1.1-alpha.22",
-    "@backstage/core-api": "^0.1.1-alpha.22",
+    "@backstage/core-api": "0.1.1-alpha.22",
     "@backstage/theme": "^0.1.1-alpha.22",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/packages/create-app/templates/default-app/.gitignore.hbs
+++ b/packages/create-app/templates/default-app/.gitignore.hbs
@@ -1,4 +1,3 @@
-
 # Logs
 logs
 *.log

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -16,7 +16,7 @@
     "test:all": "lerna run test -- --coverage",
     "lint": "lerna run lint --since origin/master --",
     "lint:all": "lerna run lint --",
-    "create-plugin": "backstage-cli create-plugin",
+    "create-plugin": "backstage-cli create-plugin --scope backstage --no-private",
     "remove-plugin": "backstage-cli remove-plugin"
   },
   "workspaces": {

--- a/packages/e2e-test/src/e2e-test.ts
+++ b/packages/e2e-test/src/e2e-test.ts
@@ -81,7 +81,11 @@ async function buildDistWorkspace(workspaceName: string, rootDir: string) {
     const path = paths.resolveOwnRoot(pkgJsonPath);
     const pkgTemplate = await fs.readFile(path, 'utf8');
     const { dependencies = {}, devDependencies = {} } = JSON.parse(
-      handlebars.compile(pkgTemplate)({ version: '0.0.0' }),
+      handlebars.compile(pkgTemplate)({
+        version: '0.0.0',
+        privatePackage: true,
+        scopeName: '@backstage',
+      }),
     );
 
     Array<string>()

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -46,6 +46,9 @@ const useStyles = makeStyles(theme => ({
     gridTemplateColumns: '250px 1fr',
     gridColumnGap: theme.spacing(2),
   },
+  buttonSpacing: {
+    marginLeft: theme.spacing(2),
+  },
 }));
 
 const CatalogPageContents = () => {
@@ -56,6 +59,7 @@ const CatalogPageContents = () => {
     reload,
     matchingEntities,
     availableTags,
+    isCatalogEmpty,
   } = useFilteredEntities();
   const configApi = useApi(configApiRef);
   const catalogApi = useApi(catalogApiRef);
@@ -141,6 +145,9 @@ const CatalogPageContents = () => {
     [isStarredEntity, userId, orgName],
   );
 
+  const showAddExampleEntities =
+    configApi.has('catalog.exampleEntityLocations') && isCatalogEmpty;
+
   return (
     <CatalogLayout>
       <CatalogTabs
@@ -158,6 +165,16 @@ const CatalogPageContents = () => {
           >
             Create Component
           </Button>
+          {showAddExampleEntities && (
+            <Button
+              className={styles.buttonSpacing}
+              variant="outlined"
+              color="primary"
+              onClick={addMockData}
+            >
+              Add example components
+            </Button>
+          )}
           <SupportButton>All your software catalog entities</SupportButton>
         </ContentHeader>
         <div className={styles.contentWrapper}>
@@ -174,7 +191,6 @@ const CatalogPageContents = () => {
             entities={matchingEntities}
             loading={loading}
             error={error}
-            onAddMockData={addMockData}
           />
         </div>
       </Content>

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -46,7 +46,6 @@ describe('CatalogTable component', () => {
           entities={[]}
           loading={false}
           error={{ code: 'error' }}
-          onAddMockData={() => {}}
         />,
       ),
     );
@@ -63,7 +62,6 @@ describe('CatalogTable component', () => {
           titlePreamble="Owned"
           entities={entities}
           loading={false}
-          onAddMockData={() => {}}
         />,
       ),
     );

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -16,11 +16,10 @@
 import { Entity, LocationSpec } from '@backstage/catalog-model';
 import { Table, TableColumn, TableProps } from '@backstage/core';
 import { Chip, Link } from '@material-ui/core';
-import Add from '@material-ui/icons/Add';
 import Edit from '@material-ui/icons/Edit';
 import GitHub from '@material-ui/icons/GitHub';
 import { Alert } from '@material-ui/lab';
-import React, { Dispatch } from 'react';
+import React from 'react';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 import { findLocationForEntityMeta } from '../../data/utils';
 import { useStarredEntities } from '../../hooks/useStarredEntites';
@@ -87,7 +86,6 @@ type CatalogTableProps = {
   titlePreamble: string;
   loading: boolean;
   error?: any;
-  onAddMockData: Dispatch<void>;
 };
 
 export const CatalogTable = ({
@@ -95,7 +93,6 @@ export const CatalogTable = ({
   loading,
   error,
   titlePreamble,
-  onAddMockData,
 }: CatalogTableProps) => {
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
 
@@ -150,13 +147,6 @@ export const CatalogTable = ({
         tooltip: favouriteEntityTooltip(isStarred),
         onClick: () => toggleStarredEntity(rowData),
       };
-    },
-    {
-      icon: () => <Add />,
-      tooltip: 'Add example components',
-      isFreeAction: true,
-      onClick: onAddMockData,
-      hidden: !(entities && entities.length === 0),
     },
   ];
 

--- a/plugins/catalog/src/filter/EntityFilterGroupsProvider.tsx
+++ b/plugins/catalog/src/filter/EntityFilterGroupsProvider.tsx
@@ -62,6 +62,7 @@ function useProvideEntityFilters(): FilterGroupsContext {
   }>({});
   const [matchingEntities, setMatchingEntities] = useState<Entity[]>([]);
   const [availableTags, setAvailableTags] = useState<string[]>([]);
+  const [isCatalogEmpty, setCatalogEmpty] = useState<boolean>(false);
 
   useEffect(() => {
     doReload();
@@ -86,6 +87,7 @@ function useProvideEntityFilters(): FilterGroupsContext {
       ),
     );
     setAvailableTags(collectTags(entities));
+    setCatalogEmpty(entities !== undefined && entities.length === 0);
   }, [entities, error]);
 
   const register = useCallback(
@@ -143,6 +145,7 @@ function useProvideEntityFilters(): FilterGroupsContext {
     filterGroupStates,
     matchingEntities,
     availableTags,
+    isCatalogEmpty,
   };
 }
 

--- a/plugins/catalog/src/filter/context.ts
+++ b/plugins/catalog/src/filter/context.ts
@@ -33,6 +33,7 @@ export type FilterGroupsContext = {
   filterGroupStates: { [filterGroupId: string]: FilterGroupStates };
   matchingEntities: Entity[];
   availableTags: string[];
+  isCatalogEmpty: boolean;
 };
 
 /**

--- a/plugins/catalog/src/filter/useFilteredEntities.ts
+++ b/plugins/catalog/src/filter/useFilteredEntities.ts
@@ -31,6 +31,7 @@ export function useFilteredEntities() {
     error: context.error,
     matchingEntities: context.matchingEntities,
     availableTags: context.availableTags,
+    isCatalogEmpty: context.isCatalogEmpty,
     reload: context.reload,
   };
 }

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -26,6 +26,7 @@
     "@backstage/core-api": "^0.1.1-alpha.22",
     "@backstage/plugin-catalog": "^0.1.1-alpha.22",
     "@backstage/theme": "^0.1.1-alpha.22",
+    "@backstage/test-utils": "^0.1.1-alpha.22",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.test.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.test.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { act, render, RenderResult, waitFor } from '@testing-library/react';
+import { RecentWorkflowRunsCard } from './RecentWorkflowRunsCard';
+import { useApi } from '@backstage/core-api';
+import { useWorkflowRuns } from '../useWorkflowRuns';
+import { wrapInTestApp } from '@backstage/test-utils';
+// const useWorkflowRunsMock = jest.fn();
+jest.mock('../useWorkflowRuns', () => ({
+  useWorkflowRuns: jest.fn(),
+}));
+jest.mock('@backstage/core-api');
+
+describe('<RecentWorkflowRunsCard />', () => {
+  const entity = {
+    apiVersion: 'v1',
+    kind: 'Component',
+    metadata: {
+      name: 'software',
+      annotations: {
+        'github.com/project-slug': 'theorg/the-service',
+      },
+    },
+    spec: {
+      owner: 'guest',
+      type: 'service',
+      lifecycle: 'production',
+    },
+  };
+
+  const workflowRuns = [1, 2, 3, 4, 5].map(n => ({
+    id: `run-id-${n}`,
+    message: `Commit message for workflow ${n}`,
+    source: { branchName: `branch-${n}` },
+    status: 'completed',
+  }));
+  const mockErrorApi = { post: jest.fn() };
+
+  beforeEach(() => {
+    (useWorkflowRuns as jest.Mock).mockReturnValue([{ runs: workflowRuns }]);
+    (useApi as jest.Mock).mockReturnValue(mockErrorApi);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders a table with a row for each workflow', async () => {
+    let subject: RenderResult;
+    await act(async () => {
+      subject = render(
+        wrapInTestApp(<RecentWorkflowRunsCard entity={entity} />),
+      );
+    });
+
+    await waitFor(() => {
+      workflowRuns.forEach(run => {
+        expect(subject.getByText(run.message)).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('renders a workflow row correctly', async () => {
+    let subject: RenderResult;
+    await act(async () => {
+      subject = render(
+        wrapInTestApp(<RecentWorkflowRunsCard entity={entity} />),
+      );
+    });
+    const [run] = workflowRuns;
+    await waitFor(() => {
+      expect(subject.getByText(run.message).closest('a')).toHaveAttribute(
+        'href',
+        `/ci-cd/${run.id}`,
+      );
+      expect(subject.getByText(run.source.branchName)).toBeInTheDocument();
+    });
+  });
+
+  it('requests only the required number of workflow runs', async () => {
+    const limit = 3;
+    await act(async () => {
+      render(
+        wrapInTestApp(<RecentWorkflowRunsCard entity={entity} limit={limit} />),
+      );
+    });
+    await waitFor(() => {
+      expect(useWorkflowRuns).toHaveBeenCalledWith(
+        expect.objectContaining({ initialPageSize: limit }),
+      );
+    });
+  });
+
+  it('uses the github repo and owner from the entity annotation', async () => {
+    await act(async () => {
+      render(wrapInTestApp(<RecentWorkflowRunsCard entity={entity} />));
+    });
+    await waitFor(() => {
+      expect(useWorkflowRuns).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: 'theorg', repo: 'the-service' }),
+      );
+    });
+  });
+
+  it('filters workflows by branch if one is specified', async () => {
+    const branch = 'master';
+    await act(async () => {
+      render(
+        wrapInTestApp(
+          <RecentWorkflowRunsCard entity={entity} branch={branch} />,
+        ),
+      );
+    });
+    await waitFor(() => {
+      expect(useWorkflowRuns).toHaveBeenCalledWith(
+        expect.objectContaining({ branch }),
+      );
+    });
+  });
+
+  describe('where there is an error fetching workflows', () => {
+    const error = 'error getting workflows';
+    beforeEach(() => {
+      (useWorkflowRuns as jest.Mock).mockReturnValue([{ runs: [], error }]);
+    });
+
+    it('sends the error to the errorApi', async () => {
+      await act(async () => {
+        render(wrapInTestApp(<RecentWorkflowRunsCard entity={entity} />));
+      });
+      await waitFor(() => {
+        expect(mockErrorApi.post).toHaveBeenCalledWith(error);
+      });
+    });
+  });
+});

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import { errorApiRef, useApi } from '@backstage/core-api';
+import { GITHUB_ACTIONS_ANNOTATION } from '../useProjectName';
+import { useWorkflowRuns } from '../useWorkflowRuns';
+import React, { useEffect } from 'react';
+import { Table } from '@backstage/core';
+import { WorkflowRunStatus } from '../WorkflowRunStatus';
+import { Card, Link, TableContainer } from '@material-ui/core';
+import { generatePath, Link as RouterLink } from 'react-router-dom';
+
+const firstLine = (message: string): string => message.split('\n')[0];
+
+export const RecentWorkflowRunsCard = ({
+  entity,
+  branch,
+  dense = false,
+  limit = 5,
+}: {
+  entity: Entity;
+  branch?: string;
+  dense?: boolean;
+  limit?: number;
+}) => {
+  const errorApi = useApi(errorApiRef);
+  const [owner, repo] = (
+    entity?.metadata.annotations?.[GITHUB_ACTIONS_ANNOTATION] ?? '/'
+  ).split('/');
+  const [{ runs = [], loading, error }] = useWorkflowRuns({
+    owner,
+    repo,
+    branch,
+    initialPageSize: limit,
+  });
+  useEffect(() => {
+    if (error) {
+      errorApi.post(error);
+    }
+  }, [error, errorApi]);
+
+  return (
+    <TableContainer component={Card}>
+      <Table
+        title="Recent Workflow Runs"
+        subtitle={branch ? `Branch: ${branch}` : 'All Branches'}
+        isLoading={loading}
+        options={{
+          search: false,
+          paging: false,
+          padding: dense ? 'dense' : 'default',
+        }}
+        columns={[
+          {
+            title: 'Commit Message',
+            field: 'message',
+            render: data => (
+              <Link
+                component={RouterLink}
+                to={generatePath('./ci-cd/:id', { id: data.id! })}
+              >
+                {firstLine(data.message)}
+              </Link>
+            ),
+          },
+          { title: 'Branch', field: 'source.branchName' },
+          { title: 'Status', field: 'status', render: WorkflowRunStatus },
+        ]}
+        data={runs}
+      />
+    </TableContainer>
+  );
+};

--- a/plugins/github-actions/src/components/Cards/index.ts
+++ b/plugins/github-actions/src/components/Cards/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { LatestWorkflowRunCard, LatestWorkflowsForBranchCard } from './Cards';
+export { RecentWorkflowRunsCard } from './RecentWorkflowRunsCard';

--- a/plugins/github-actions/src/components/useWorkflowRuns.ts
+++ b/plugins/github-actions/src/components/useWorkflowRuns.ts
@@ -24,10 +24,12 @@ export function useWorkflowRuns({
   owner,
   repo,
   branch,
+  initialPageSize = 5,
 }: {
   owner: string;
   repo: string;
   branch?: string;
+  initialPageSize: number;
 }) {
   const api = useApi(githubActionsApiRef);
   const auth = useApi(githubAuthApiRef);
@@ -36,7 +38,7 @@ export function useWorkflowRuns({
 
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(5);
+  const [pageSize, setPageSize] = useState(initialPageSize);
 
   const { loading, value: runs, retry, error } = useAsyncRetry<
     WorkflowRun[]


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a widget to show recent git workflow runs to the 
github actions plugin. The default setting is the last
5 runs across all branches but both branch and the
number of runs are configurable. 

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
