### PR TITLE
Add window config loader and allow composition of loaders

### DIFF
--- a/.changeset/3194.md
+++ b/.changeset/3194.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core': patch
+---
+
+Extend default config loader to read config from the window object.
+
+Config will be read from `window.__APP_CONFIG__` which should be an object.

--- a/packages/core/src/api-wrappers/createApp.tsx
+++ b/packages/core/src/api-wrappers/createApp.tsx
@@ -67,6 +67,13 @@ export const defaultConfigLoader: AppConfigLoader = async (
     }
   }
 
+  const windowAppConfig = (window as any).__APP_CONFIG__;
+  if (windowAppConfig) {
+    configs.push({
+      context: 'window',
+      data: windowAppConfig,
+    });
+  }
   return configs;
 };
 


### PR DESCRIPTION
* Adds a window config loader which loads config from the window object under the  `__APP_CONFIG__` key. This config is assumed to be represented as an object.

* Adds a function which allows the user to compose config loaders. This means the user can choose which loads they want and the precedence of each. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
