### PR TITLE
Fail when adding duplicate locations using the dry run flag

### DIFF
--- a/.changeset/thirty-fireants-occur.md
+++ b/.changeset/thirty-fireants-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Detect a duplicate entities when adding locations through dry run

--- a/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
@@ -196,7 +196,7 @@ describe('DefaultLocationServiceTest', () => {
           { type: 'url', target: 'https://backstage.io/catalog-info.yaml' },
           true,
         ),
-      ).rejects.toThrowError('Duplicate nested entity: foo');
+      ).rejects.toThrowError('Duplicate nested entity: location:default/foo');
     });
 
     it('should return exists false when the location does not exist beforehand', async () => {

--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -19,6 +19,7 @@ import {
   LocationSpec,
   LOCATION_ANNOTATION,
   ORIGIN_LOCATION_ANNOTATION,
+  stringifyEntityRef,
 } from '@backstage/catalog-model';
 import {
   CatalogProcessingOrchestrator,
@@ -69,13 +70,18 @@ export class DefaultLocationService implements LocationService {
       });
 
       if (processed.ok) {
-        const { metadata, kind } = processed.completedEntity;
         if (
           entities.some(
-            e => e.metadata.name === metadata.name && e.kind === kind,
+            e =>
+              stringifyEntityRef(e) ===
+              stringifyEntityRef(processed.completedEntity),
           )
         ) {
-          throw new Error(`Duplicate nested entity: ${metadata.name}`);
+          throw new Error(
+            `Duplicate nested entity: ${stringifyEntityRef(
+              processed.completedEntity,
+            )}`,
+          );
         }
         unprocessedEntities.push(...processed.deferredEntities);
         entities.push(processed.completedEntity);

--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -60,7 +60,7 @@ export class DefaultLocationService implements LocationService {
   ): Promise<Entity[]> {
     const currentEntity = unprocessed.pop();
     if (!currentEntity) {
-      return [];
+      return entities;
     }
     const processed = await this.orchestrator.process({
       entity: currentEntity.entity,


### PR DESCRIPTION
This change here adds in logic to the DefaultLocationService that will prematurely terminate the dry run addition of locations if there is a duplicate entity in the unprocessed entities.
Adding this logic here will avoid an infinite loop if a monorepo arch is used (for example if a target references itself). It will also enforce some best practices.
I have also added tests.

Signed-off-by: Nicolas Arnold <nic@roadie.io>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
