### PR TITLE
Send heartbeat stream to frontend

### DIFF
--- a/.changeset/moody-trainers-repair.md
+++ b/.changeset/moody-trainers-repair.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Send heartbeat stream to frontend every 2 seconds (by default)

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -394,7 +394,7 @@ export interface TaskContext {
 }
 
 // @public
-export type TaskEventType = 'completion' | 'log';
+export type TaskEventType = 'completion' | 'log' | 'connection';
 
 // @public
 export class TaskManager implements TaskContext {

--- a/plugins/scaffolder-backend/config.d.ts
+++ b/plugins/scaffolder-backend/config.d.ts
@@ -53,5 +53,6 @@ export interface Config {
        */
       visibility?: 'public' | 'private';
     };
+    heartBeatPoll?: number;
   };
 }

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
@@ -54,7 +54,7 @@ export type SerializedTask = {
  *
  * @public
  */
-export type TaskEventType = 'completion' | 'log';
+export type TaskEventType = 'completion' | 'log' | 'connection';
 
 /**
  * SerializedTaskEvent

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -268,7 +268,7 @@ export async function createRouter(
       let shouldUnsubscribe = false;
 
       // Send heartbeat every 2 seconds so the frontend/proxy knows the connection is still alive
-      const timeout = setTimeout(() => {
+      const interval = setInterval(() => {
         if (!shouldUnsubscribe) {
           res.write(
             `event: connection\ndata: ${JSON.stringify({
@@ -303,7 +303,7 @@ export async function createRouter(
           // res.flush() is only available with the compression middleware
           res.flush?.();
           if (shouldUnsubscribe) {
-            clearTimeout(timeout);
+            clearTimeout(interval);
             unsubscribe();
           }
         },

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -42,7 +42,7 @@ type TemplateParameterSchema = {
 };
 
 export type LogEvent = {
-  type: 'log' | 'completion';
+  type: 'log' | 'completion' | 'connection';
   body: {
     message: string;
     stepId?: string;

--- a/plugins/scaffolder/src/components/hooks/useEventStream.ts
+++ b/plugins/scaffolder/src/components/hooks/useEventStream.ts
@@ -172,6 +172,8 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
             switch (event.type) {
               case 'log':
                 return collectedLogEvents.push(event);
+              case 'connection':
+                return undefined;
               case 'completion':
                 emitLogs();
                 dispatch({ type: 'COMPLETED', data: event });


### PR DESCRIPTION
The following change adds in a new event to the eventstream that signals the request is still alive. Although the request headers contain the `keep-alive` header, this is not enough to tell a reverse proxy (or in some case browsers) that the connection is still open.

For example, if you have an nginx proxy in front of backstage the default `proxy_read_timeout` is set to 60s. If no event is sent in the eventstream during this time, NGINX cuts the request with a `(failed)net::ERR_CONNECTION_CLOSED`. We don't want this to happen.

As a way to mitigate this, I have added support to send a heartbeat event every 2 seconds. This should avoid this abrupt connection closure.

Changes to both the frontend and the backend are included in this.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
